### PR TITLE
Update checkout to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: red-gate/release-actions
         path: release-actions


### PR DESCRIPTION
Updates checkout to v3 which removes a Node 12 warning

![image](https://user-images.githubusercontent.com/17652619/216086903-19301695-ad2d-49c9-87ef-4d3760663154.png)
