### PR TITLE
Bump default version to v2.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   ref:
     description: 'The branch, tag or SHA to checkout. Defaults to specific commit for this version of the Release Actions.'
-    default: 'v1.1.0'
+    default: 'v2.0.0'
     required: false
 runs:
   using: 'composite'


### PR DESCRIPTION
Bump default version to v2.0.0 so we can release v2.0.0 of the action.

Release notes:
 - (Breaking) Removed old release notes action
 - (Breaking) Removed nuget action which was a no-op
 - Fix case where an error is not handled if an uploaded a release artifact is rejected