### PR TITLE
Update-release-action-version-to-3.2.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   ref:
     description: 'The branch, tag or SHA to checkout. Defaults to specific commit for this version of the Release Actions.'
-    default: 'v3.2.1'
+    default: 'v3.2.2'
     required: false
 runs:
   using: 'composite'


### PR DESCRIPTION
Update-release-action-version-to-3.2.2
https://github.com/red-gate/release-actions/releases/tag/v3.2.2

Brings in a fix to the github workflow action which was accidentally released